### PR TITLE
Add ChatGPT integration to Hydroxite

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "launch": "cargo run --release"
+  }
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ rfd = "0.13.0"
 syntect = "5.1.0"
 walkdir = "2.3.3"
 image = { version = "0.24", features = ["png"] }
+reqwest = { version = "0.11", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 # i want to fricking die
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["winuser", "windef"] }


### PR DESCRIPTION
Add AI integration to the text editor, allowing users to generate responses using an AI API by pressing Ctrl+I.

* **Cargo.toml**
  - Add `reqwest` dependency for making HTTP requests to the AI API.
  - Add `serde` and `serde_json` dependencies for handling JSON responses.

* **src/main.rs**
  - Add `AIConfig` struct to store the API key and prompt.
  - Add `fetch_ai_response` function to make a request to the AI API and return the response.
  - Add `show_ai_prompt_dialog` function to display a dialog for entering the AI prompt and API key.
  - Modify the `update` function to handle the Ctrl+I key press event and show the AI prompt dialog.
  - Modify the `show_editor` function to display the AI response in the editor.

* **.devcontainer/devcontainer.json**
  - Add a new devcontainer configuration file with a launch task to run the application.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nap123-sys/Hydroxite?shareId=0dd33135-8b98-4917-985d-ec670553ddf2).